### PR TITLE
Replaced state=running with state-started

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -127,7 +127,7 @@
     - monitconfig
     
 - name: Make sure monit is running
-  service: name=monit state=running enabled=yes
+  service: name=monit state=started enabled=yes
   become: yes
   tags:
     - monitconfig


### PR DESCRIPTION
[DEPRECATION WARNING]: state=running is deprecated. Please use state=started. This feature will be removed in version 2.7