### PR TITLE
Add checks on install znc-dbg & add support for Debian Stretch and Bu…

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,13 +9,13 @@
   apt_repository: repo=ppa:teward/znc state=present
   tags:
     - zncinstall
+  when: ansible_distribution == 'Ubuntu'
     
 - name: Install packages
   apt: name={{item}} state=latest
   become: yes
   with_items:
     - znc
-    - znc-dbg
     - znc-dev
     - znc-perl
     - znc-python
@@ -25,6 +25,17 @@
   tags:
     - zncinstall
     - monitinstall
+
+- name: Install znc-dbg packages
+  apt: name={{item}} state=latest
+  become: yes
+  with_items:
+    - znc-dbg
+  tags:
+    - zncinstall
+    - monitinstall
+  when: ansible_distribution == 'Debian' and ansible_distribution_release == 'stretch'
+
 # Create the ZNC user if needed
 - name: Create znc group
   group: name={{znc_system_group}}


### PR DESCRIPTION
…ster

Check if install distro is Ubuntu when installing PPA. Only install znc-dbg if distro Debian Stretch (Ubuntu and Debian Buster now > 1.7 and don't require it)